### PR TITLE
Removing 22 ssh rule from NSG

### DIFF
--- a/docs/topics/architecture.md
+++ b/docs/topics/architecture.md
@@ -132,20 +132,6 @@ Once the input is validated, the template generator is invoked which will conver
           },
 {{end}}
           {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
             "name": "allow_kube_tls",
             "properties": {
               "access": "Allow",

--- a/pkg/armhelpers/azurestack/httpMockClientData/deployVMRequest.json
+++ b/pkg/armhelpers/azurestack/httpMockClientData/deployVMRequest.json
@@ -1197,20 +1197,6 @@
                     "properties": {
                         "securityRules": [
                             {
-                                "name": "allow_ssh",
-                                "properties": {
-                                    "access": "Allow",
-                                    "description": "Allow SSH traffic to master",
-                                    "destinationAddressPrefix": "*",
-                                    "destinationPortRange": "22-22",
-                                    "direction": "Inbound",
-                                    "priority": 101,
-                                    "protocol": "Tcp",
-                                    "sourceAddressPrefix": "*",
-                                    "sourcePortRange": "*"
-                                }
-                            },
-                            {
                                 "name": "allow_kube_tls",
                                 "properties": {
                                     "access": "Allow",

--- a/pkg/armhelpers/httpMockClientData/deployVMRequest.json
+++ b/pkg/armhelpers/httpMockClientData/deployVMRequest.json
@@ -1163,20 +1163,6 @@
                     "properties": {
                         "securityRules": [
                             {
-                                "name": "allow_ssh",
-                                "properties": {
-                                    "access": "Allow",
-                                    "description": "Allow SSH traffic to master",
-                                    "destinationAddressPrefix": "*",
-                                    "destinationPortRange": "22-22",
-                                    "direction": "Inbound",
-                                    "priority": 101,
-                                    "protocol": "Tcp",
-                                    "sourceAddressPrefix": "*",
-                                    "sourcePortRange": "*"
-                                }
-                            },
-                            {
                                 "name": "allow_kube_tls",
                                 "properties": {
                                     "access": "Allow",

--- a/pkg/engine/armresources_test.go
+++ b/pkg/engine/armresources_test.go
@@ -200,20 +200,6 @@ func TestGenerateARMResourcesWithVMSSAgentPool(t *testing.T) {
 			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 				SecurityRules: &[]network.SecurityRule{
 					{
-						Name: to.StringPtr("allow_ssh"),
-						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Access:                   network.SecurityRuleAccessAllow,
-							Description:              to.StringPtr("Allow SSH traffic to master"),
-							DestinationAddressPrefix: to.StringPtr("*"),
-							DestinationPortRange:     to.StringPtr("22-22"),
-							Direction:                network.SecurityRuleDirectionInbound,
-							Priority:                 to.Int32Ptr(101),
-							Protocol:                 network.SecurityRuleProtocolTCP,
-							SourceAddressPrefix:      to.StringPtr("*"),
-							SourcePortRange:          to.StringPtr("*"),
-						},
-					},
-					{
 						Name: to.StringPtr("allow_kube_tls"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 							Access:                   network.SecurityRuleAccessAllow,
@@ -1173,20 +1159,6 @@ func TestGenerateARMResourceWithVMASAgents(t *testing.T) {
 				SecurityRules: &[]network.SecurityRule{
 					{
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Description:              to.StringPtr("Allow SSH traffic to master"),
-							Protocol:                 network.SecurityRuleProtocol("Tcp"),
-							SourcePortRange:          to.StringPtr("*"),
-							DestinationPortRange:     to.StringPtr("22-22"),
-							SourceAddressPrefix:      to.StringPtr("*"),
-							DestinationAddressPrefix: to.StringPtr("*"),
-							Access:                   network.SecurityRuleAccess("Allow"),
-							Priority:                 to.Int32Ptr(101),
-							Direction:                network.SecurityRuleDirection("Inbound"),
-						},
-						Name: to.StringPtr("allow_ssh"),
-					},
-					{
-						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 							Description:              to.StringPtr("Allow kube-apiserver (tls) traffic to master"),
 							Protocol:                 network.SecurityRuleProtocol("Tcp"),
 							SourcePortRange:          to.StringPtr("*"),
@@ -1435,20 +1407,6 @@ func TestGenerateARMResourcesWithVMSSAgentPoolAndSLB(t *testing.T) {
 			Type:     to.StringPtr("Microsoft.Network/networkSecurityGroups"),
 			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 				SecurityRules: &[]network.SecurityRule{
-					{
-						Name: to.StringPtr("allow_ssh"),
-						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Access:                   network.SecurityRuleAccessAllow,
-							Description:              to.StringPtr("Allow SSH traffic to master"),
-							DestinationAddressPrefix: to.StringPtr("*"),
-							DestinationPortRange:     to.StringPtr("22-22"),
-							Direction:                network.SecurityRuleDirectionInbound,
-							Priority:                 to.Int32Ptr(101),
-							Protocol:                 network.SecurityRuleProtocolTCP,
-							SourceAddressPrefix:      to.StringPtr("*"),
-							SourcePortRange:          to.StringPtr("*"),
-						},
-					},
 					{
 						Name: to.StringPtr("allow_kube_tls"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{

--- a/pkg/engine/masterarmresources_test.go
+++ b/pkg/engine/masterarmresources_test.go
@@ -407,20 +407,6 @@ func TestCreateKubernetesMasterResourcesPrivateCluster(t *testing.T) {
 			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 				SecurityRules: &[]network.SecurityRule{
 					{
-						Name: to.StringPtr("allow_ssh"),
-						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Access:                   network.SecurityRuleAccessAllow,
-							Description:              to.StringPtr("Allow SSH traffic to master"),
-							DestinationAddressPrefix: to.StringPtr("*"),
-							DestinationPortRange:     to.StringPtr("22-22"),
-							Direction:                network.SecurityRuleDirectionInbound,
-							Priority:                 to.Int32Ptr(101),
-							Protocol:                 network.SecurityRuleProtocolTCP,
-							SourceAddressPrefix:      to.StringPtr("*"),
-							SourcePortRange:          to.StringPtr("*"),
-						},
-					},
-					{
 						Name: to.StringPtr("allow_kube_tls"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 							Access:                   network.SecurityRuleAccessAllow,
@@ -762,20 +748,6 @@ func TestCreateKubernetesMasterResourcesVMSS(t *testing.T) {
 		SecurityGroup: network.SecurityGroup{
 			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 				SecurityRules: &[]network.SecurityRule{
-					{
-						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Description:              to.StringPtr("Allow SSH traffic to master"),
-							Protocol:                 network.SecurityRuleProtocol("Tcp"),
-							SourcePortRange:          to.StringPtr("*"),
-							DestinationPortRange:     to.StringPtr("22-22"),
-							SourceAddressPrefix:      to.StringPtr("*"),
-							DestinationAddressPrefix: to.StringPtr("*"),
-							Access:                   network.SecurityRuleAccess("Allow"),
-							Priority:                 to.Int32Ptr(101),
-							Direction:                network.SecurityRuleDirection("Inbound"),
-						},
-						Name: to.StringPtr("allow_ssh"),
-					},
 					{
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 							Description:              to.StringPtr("Allow kube-apiserver (tls) traffic to master"),

--- a/pkg/engine/networksecuritygroups.go
+++ b/pkg/engine/networksecuritygroups.go
@@ -14,21 +14,6 @@ func CreateNetworkSecurityGroup(cs *api.ContainerService) NetworkSecurityGroupAR
 		APIVersion: "[variables('apiVersionNetwork')]",
 	}
 
-	sshRule := network.SecurityRule{
-		Name: to.StringPtr("allow_ssh"),
-		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Access:                   network.SecurityRuleAccessAllow,
-			Description:              to.StringPtr("Allow SSH traffic to master"),
-			DestinationAddressPrefix: to.StringPtr("*"),
-			DestinationPortRange:     to.StringPtr("22-22"),
-			Direction:                network.SecurityRuleDirectionInbound,
-			Priority:                 to.Int32Ptr(101),
-			Protocol:                 network.SecurityRuleProtocolTCP,
-			SourceAddressPrefix:      to.StringPtr("*"),
-			SourcePortRange:          to.StringPtr("*"),
-		},
-	}
-
 	kubeTLSRule := network.SecurityRule{
 		Name: to.StringPtr("allow_kube_tls"),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
@@ -50,7 +35,6 @@ func CreateNetworkSecurityGroup(cs *api.ContainerService) NetworkSecurityGroupAR
 	}
 
 	securityRules := []network.SecurityRule{
-		sshRule,
 		kubeTLSRule,
 	}
 

--- a/pkg/engine/networksecuritygroups_test.go
+++ b/pkg/engine/networksecuritygroups_test.go
@@ -48,20 +48,6 @@ func TestCreateNetworkSecurityGroup(t *testing.T) {
 			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 				SecurityRules: &[]network.SecurityRule{
 					{
-						Name: to.StringPtr("allow_ssh"),
-						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Access:                   network.SecurityRuleAccessAllow,
-							Description:              to.StringPtr("Allow SSH traffic to master"),
-							DestinationAddressPrefix: to.StringPtr("*"),
-							DestinationPortRange:     to.StringPtr("22-22"),
-							Direction:                network.SecurityRuleDirectionInbound,
-							Priority:                 to.Int32Ptr(101),
-							Protocol:                 network.SecurityRuleProtocolTCP,
-							SourceAddressPrefix:      to.StringPtr("*"),
-							SourcePortRange:          to.StringPtr("*"),
-						},
-					},
-					{
 						Name: to.StringPtr("allow_kube_tls"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 							Access:                   network.SecurityRuleAccessAllow,

--- a/pkg/engine/transform/transformtestfiles/k8s_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_scale_template.json
@@ -2003,20 +2003,6 @@
       "properties": {
         "securityRules": [
           {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
             "name": "allow_kube_tls",
             "properties": {
               "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_scale_template.json
@@ -1679,20 +1679,6 @@
         "properties": {
           "securityRules": [
             {
-              "name": "allow_ssh",
-              "properties": {
-                "access": "Allow",
-                "description": "Allow SSH traffic to master",
-                "destinationAddressPrefix": "*",
-                "destinationPortRange": "22-22",
-                "direction": "Inbound",
-                "priority": 101,
-                "protocol": "Tcp",
-                "sourceAddressPrefix": "*",
-                "sourcePortRange": "*"
-              }
-            },
-            {
               "name": "allow_kube_tls",
               "properties": {
                 "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_template.json
@@ -1728,20 +1728,6 @@
         "properties": {
           "securityRules": [
             {
-              "name": "allow_ssh",
-              "properties": {
-                "access": "Allow",
-                "description": "Allow SSH traffic to master",
-                "destinationAddressPrefix": "*",
-                "destinationPortRange": "22-22",
-                "direction": "Inbound",
-                "priority": 101,
-                "protocol": "Tcp",
-                "sourceAddressPrefix": "*",
-                "sourcePortRange": "*"
-              }
-            },
-            {
               "name": "allow_kube_tls",
               "properties": {
                 "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_scale_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_scale_template.json
@@ -1602,20 +1602,6 @@
       "properties": {
         "securityRules": [
           {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
             "name": "allow_kube_tls",
             "properties": {
               "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_slb_vmss_template.json
@@ -1651,20 +1651,6 @@
       "properties": {
         "securityRules": [
           {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
             "name": "allow_kube_tls",
             "properties": {
               "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_template.json
@@ -2014,20 +2014,6 @@
       "properties": {
         "securityRules": [
           {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
             "name": "allow_kube_tls",
             "properties": {
               "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_template_jumpbox.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_template_jumpbox.json
@@ -3197,20 +3197,6 @@
             "properties": {
                 "securityRules": [
                     {
-                        "name": "allow_ssh",
-                        "properties": {
-                            "access": "Allow",
-                            "description": "Allow SSH traffic to master",
-                            "destinationAddressPrefix": "*",
-                            "destinationPortRange": "22-22",
-                            "direction": "Inbound",
-                            "priority": 101,
-                            "protocol": "Tcp",
-                            "sourceAddressPrefix": "*",
-                            "sourcePortRange": "*"
-                        }
-                    },
-                    {
                         "name": "allow_kube_tls",
                         "properties": {
                             "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_template_kms.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_template_kms.json
@@ -2014,20 +2014,6 @@
       "properties": {
         "securityRules": [
           {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
             "name": "allow_kube_tls",
             "properties": {
               "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_template_kms_upgrade.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_template_kms_upgrade.json
@@ -2014,20 +2014,6 @@
       "properties": {
         "securityRules": [
           {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
             "name": "allow_kube_tls",
             "properties": {
               "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_upgrade_template_jumpbox.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_upgrade_template_jumpbox.json
@@ -3197,20 +3197,6 @@
             "properties": {
                 "securityRules": [
                     {
-                        "name": "allow_ssh",
-                        "properties": {
-                            "access": "Allow",
-                            "description": "Allow SSH traffic to master",
-                            "destinationAddressPrefix": "*",
-                            "destinationPortRange": "22-22",
-                            "direction": "Inbound",
-                            "priority": 101,
-                            "protocol": "Tcp",
-                            "sourceAddressPrefix": "*",
-                            "sourcePortRange": "*"
-                        }
-                    },
-                    {
                         "name": "allow_kube_tls",
                         "properties": {
                             "access": "Allow",

--- a/pkg/engine/transform/transformtestfiles/k8s_vnet_template.json
+++ b/pkg/engine/transform/transformtestfiles/k8s_vnet_template.json
@@ -1948,20 +1948,6 @@
       "properties": {
         "securityRules": [
           {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
             "name": "allow_kube_tls",
             "properties": {
               "access": "Allow",


### PR DESCRIPTION
Removes the `allow ssh port 22` NSG rule from the aks-engine clusters that get created as part of the e2e aks-engine tests